### PR TITLE
Update `url()` regex to ignore SVG fragment IDs

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -279,7 +279,7 @@ export function transpileStyleSheet(sheetSrc: string, srcUrl?: string): string {
   }
 
   p.sheetSrc = p.sheetSrc.replace(
-    /url\(["']*([^)"']+)["']*\)/g,
+    /url\(["']*([^#)"'][^)"']*)["']*\)/g,
     (match, url) => {
       return `url(${new URL(url, srcUrl)})`;
     }


### PR DESCRIPTION
This PR updates the regex that rewrites CSS `url()` functions so that instances of SVG fragment identifiers are ignored.

We recently noticed that `clip-path` rules on our site were broken. Rules that looked like `clip-path: url(#fragmentID);` were being rewritten to include the CSS filename, like so: `clip-path: url('https://website.com/styles.css#fragmentID');`. Since CSS files do not support document fragment identifiers, the only reasonable application of the `url()` function where the parameter starts with a `#` is to reference a fragment of the HTML document, and thus these values should not be rewritten with absolute URLs. The MDN page for the `url()` function backs this up: https://developer.mozilla.org/en-US/docs/Web/CSS/url().

I also created this test bed for the new regex, to run it against all of the examples provided in the `url()` docs page and verify that everything matches as expected: https://regexr.com/6hnr9