### PR TITLE
fix: prevents querySelectorAll on media queries

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -290,7 +290,8 @@ export function transpileStyleSheet(sheetSrc: string, srcUrl?: string): string {
 function handleContainerProps(rule: Rule, p) {
   const hasLongHand = rule.block.contents.includes("container-");
   const hasShortHand = rule.block.contents.includes("container:");
-  if (!hasLongHand && !hasShortHand) return;
+  const isInvalid = rule.selector.startsWith('@');
+  if (isInvalid || !hasLongHand && !hasShortHand) return;
   let containerName, containerType;
   if (hasLongHand) {
     containerName = /container-name\s*:([^;}]+)/

--- a/tests/container_classname.html
+++ b/tests/container_classname.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<style></style>
+<div style="width: 100px">
+  <h1>Ohai</h1>
+</div>
+<script type="module">
+  import { doubleRaf, testSuite, assert } from "./test-utils.js";
+  import { transpileStyleSheet } from "/cqfill.js";
+
+  testSuite("Manual transpiling", async () => {
+    const parsed = transpileStyleSheet(`
+      @media (max-width: 767px) {
+        .container- {
+          width: 50px;
+        }
+      }
+      div {
+        outline: 1px solid red;
+        resize: both;
+        overflow: auto;
+        container-type: size;
+        height: 100px;
+      }
+      h1 {
+        font-size: 10px;
+      }
+      @container (min-width: 200px) {
+        h1 {
+          font-size: 30px;
+        }
+      }
+      @container (max-width: 200px) {
+        h1 {
+          font-size: 20px;
+        }
+      }
+    `);
+    document.querySelector("style").innerHTML = parsed;
+
+    {
+      await doubleRaf();
+      const { fontSize } = getComputedStyle(document.querySelector("div h1"));
+      assert(
+        fontSize === "20px",
+        `Expected font-size to be 20px, got ${fontSize}`
+      );
+    }
+    document.querySelector("div").style = "width: 300px";
+    {
+      await doubleRaf();
+      const { fontSize } = getComputedStyle(document.querySelector("div h1"));
+      assert(
+        fontSize === "30px",
+        `Expected font-size to be 30px, got ${fontSize}`
+      );
+    }
+  });
+</script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,6 +11,7 @@
 <script type="module">
   const TESTS = [
     "simple",
+    "container_classname",
     "dynamic",
     "nested",
     "and",
@@ -62,7 +63,7 @@
       iframe.src = `./${test}.html`;
       const result = await nextEventTimeout(window, "message", 2000);
       testResults[test] = result.data;
-      results.innerHTML += `<span><a href="./${test}.html">${test}</a></span><span>${result.data}</span>`;
+      results.innerHTML += `<span><a href="./${test}.html">${test}</a></span><span>${JSON.stringify(result.data)}</span>`;
     }
     return testResults;
   }


### PR DESCRIPTION
This leads to an uncaught dom exception. See #23