### PR TITLE
Improve updating performance

### DIFF
--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -132,13 +132,13 @@ export const enum WritingAxis {
   Vertical,
 }
 
-export interface TreeContext {
+export type TreeContext = {
   cqw: number | null;
   cqh: number | null;
   fontSize: number;
   rootFontSize: number;
   writingAxis: WritingAxis;
-}
+};
 
 interface QueryContext {
   sizeFeatures: Map<SizeFeature, Value>;

--- a/src/memo.ts
+++ b/src/memo.ts
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2022 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class Reference<T> {
+  value: T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+
+export type MemoizableValue =
+  | number
+  | string
+  | boolean
+  | symbol
+  | null
+  | Reference<unknown>
+  | MemoizableValue[]
+  | {[key: number | string | symbol]: MemoizableValue};
+
+export function memoizeAndReuse<
+  TArgs extends MemoizableValue[],
+  TResult extends MemoizableValue
+>(fn: (...args: TArgs) => TResult) {
+  type Result = [TArgs, TResult];
+  let previousResult: Result | null = null;
+
+  return (...args: TArgs) => {
+    if (previousResult == null || !areEqual(previousResult[0], args)) {
+      const currentResult = fn(...args);
+      if (
+        previousResult == null ||
+        !areEqual(previousResult[1], currentResult)
+      ) {
+        previousResult = [args, currentResult];
+      }
+    }
+    return previousResult[1];
+  };
+}
+
+function areEqual(lhs: MemoizableValue, rhs: MemoizableValue) {
+  if (lhs === rhs) {
+    return true;
+  }
+
+  if (typeof lhs === typeof rhs) {
+    if (lhs !== null && rhs !== null && typeof lhs === 'object') {
+      if (Array.isArray(lhs)) {
+        if (!Array.isArray(rhs) || rhs.length !== lhs.length) {
+          return false;
+        }
+
+        for (let i = 0, length = lhs.length; i < length; i++) {
+          if (!areEqual(lhs[i], rhs[i])) {
+            return false;
+          }
+        }
+
+        return true;
+      } else if (lhs instanceof Reference) {
+        if (!(rhs instanceof Reference) || lhs.value !== rhs.value) {
+          return false;
+        }
+        return true;
+      } else {
+        const leftKeys = Object.keys(lhs);
+        if (leftKeys.length !== Object.keys(rhs).length) {
+          return false;
+        }
+
+        for (let i = 0, length = leftKeys.length; i < length; i++) {
+          const key = leftKeys[i];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          if (!areEqual(lhs[key], (rhs as any)[key])) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/src/wpt.ts
+++ b/src/wpt.ts
@@ -21,9 +21,7 @@ export function initializeForWPT() {
     return new Promise<void>(resolve => {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
-            resolve();
-          });
+          resolve();
         });
       });
     });


### PR DESCRIPTION
This is a large rework of how the polyfill performs updates in order to improve performance.

Previously, we attempted to use `ResizeObserver` as a _scheduler_ of sorts. This was achieved by observing *every* element to know when it was time to update it, and doing a `unobserve` + `observe` to force entries to be created after a mutation, thus _scheduling_ work. This way, we could work cooperatively with the browser.

Unfortunately, it ended up faster in practice to just apply mutations in place as we traverse the tree. The cost of the forced layouts when reading subsequent elements is considerably lower than waiting for the browser to issue subsequent calls to the `ResizeObserver`.

---

This PR instead adopts a far more straightforward approach to updating:

* After each mutation, we mark the entire affected _subtree_ as dirty[^1] and use `ResizeObserver.unobserve(documentElement)` + `ResizeObserver.observe(documentElement)` to _schedule_ an update.
  * As a result, we only need to observe container elements
* After each resize, we mark the affected _element_ as dirty.
* Inside the `ResizeObserver` callback, we traverse the whole tree, updating any dirty elements.

The process of _updating_ an element uses memoization and reuse:
* If arguments aren't changed, the previous value is reused
* If the return value hasn't changed, the previous value is reused

To support this, the input and output of memoizable functions must be primitive values. Additionally, it also supports a special `Reference<T>` type to selectively opt-in particular fields to cheaper referential equality checks when it makes sense (e.g. when the underlying value is itself a memoized value that retains referential equality until it changes).

[^1]: This is a performance optimization. See #56 for more details.
