### PR TITLE
fix: improve :where supports check

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -87,7 +87,7 @@ const CUSTOM_UNIT_MAP: Record<string, string> = {
   cqb: CUSTOM_UNIT_VARIABLE_CQB,
 };
 
-const SUPPORTS_WHERE_PSEUDO_CLASS = CSS.supports('selector(:where())');
+const SUPPORTS_WHERE_PSEUDO_CLASS = CSS.supports('selector(:where(div))');
 const NO_WHERE_SELECTOR = ':not(.container-query-polyfill)';
 const NO_WHERE_SELECTOR_TOKENS = parseComponentValue(
   Array.from(tokenize(NO_WHERE_SELECTOR))


### PR DESCRIPTION
Newer Firefox's have :where support but the specific check used returns false. Changing the check to be `CSS.supports('selector(:where(div))')` makes it return `true` in Firefox and makes the polyfill work there without needing the :where fallback.

Fixes #64